### PR TITLE
Allow user to pass in paragraph, font and other styles

### DIFF
--- a/src/PhpWord/Shared/Html.php
+++ b/src/PhpWord/Shared/Html.php
@@ -80,7 +80,7 @@ class Html
         self::$xpath = new \DOMXPath($dom);
         $node = $dom->getElementsByTagName('body');
 
-        self::parseNode($node->item(0), $element);
+        self::parseNode($node->item(0), $element, isset($options['styles']) ? $options['styles'] : array());
         libxml_disable_entity_loader($orignalLibEntityLoader);
     }
 


### PR DESCRIPTION
### Description

If we add this, we can pass in styles externally from the `HTML::addHtml` inside the existing `$options` param.

### Checklist:

- [ ] I have run `composer run-script check --timeout=0` and no errors were reported
- [ ] The new code is covered by unit tests (check build/coverage for coverage report)
- [ ] I have updated the documentation to describe the changes
