### PR TITLE
Add user defined node mappings

### DIFF
--- a/src/PhpWord/Shared/Html.php
+++ b/src/PhpWord/Shared/Html.php
@@ -35,6 +35,7 @@ class Html
     protected static $listIndex = 0;
     protected static $xpath;
     protected static $options;
+    protected static $userDefinedNodeMappings = array();
 
     /**
      * Add HTML parts.
@@ -131,36 +132,19 @@ class Html
             }
         }
 
-        // Node mapping table
-        $nodes = array(
-                              // $method        $node   $element    $styles     $data   $argument1      $argument2
-            'p'         => array('Paragraph',   $node,  $element,   $styles,    null,   null,           null),
-            'h1'        => array('Heading',     null,   $element,   $styles,    null,   'Heading1',     null),
-            'h2'        => array('Heading',     null,   $element,   $styles,    null,   'Heading2',     null),
-            'h3'        => array('Heading',     null,   $element,   $styles,    null,   'Heading3',     null),
-            'h4'        => array('Heading',     null,   $element,   $styles,    null,   'Heading4',     null),
-            'h5'        => array('Heading',     null,   $element,   $styles,    null,   'Heading5',     null),
-            'h6'        => array('Heading',     null,   $element,   $styles,    null,   'Heading6',     null),
-            '#text'     => array('Text',        $node,  $element,   $styles,    null,   null,           null),
-            'strong'    => array('Property',    null,   null,       $styles,    null,   'bold',         true),
-            'b'         => array('Property',    null,   null,       $styles,    null,   'bold',         true),
-            'em'        => array('Property',    null,   null,       $styles,    null,   'italic',       true),
-            'i'         => array('Property',    null,   null,       $styles,    null,   'italic',       true),
-            'u'         => array('Property',    null,   null,       $styles,    null,   'underline',    'single'),
-            'sup'       => array('Property',    null,   null,       $styles,    null,   'superScript',  true),
-            'sub'       => array('Property',    null,   null,       $styles,    null,   'subScript',    true),
-            'span'      => array('Span',        $node,  null,       $styles,    null,   null,           null),
-            'font'      => array('Span',        $node,  null,       $styles,    null,   null,           null),
-            'table'     => array('Table',       $node,  $element,   $styles,    null,   null,           null),
-            'tr'        => array('Row',         $node,  $element,   $styles,    null,   null,           null),
-            'td'        => array('Cell',        $node,  $element,   $styles,    null,   null,           null),
-            'th'        => array('Cell',        $node,  $element,   $styles,    null,   null,           null),
-            'ul'        => array('List',        $node,  $element,   $styles,    $data,  null,           null),
-            'ol'        => array('List',        $node,  $element,   $styles,    $data,  null,           null),
-            'li'        => array('ListItem',    $node,  $element,   $styles,    $data,  null,           null),
-            'img'       => array('Image',       $node,  $element,   $styles,    null,   null,           null),
-            'br'        => array('LineBreak',   null,   $element,   $styles,    null,   null,           null),
-            'a'         => array('Link',        $node,  $element,   $styles,    null,   null,           null),
+        $nodes = self::getNodeMappingTable($node, $element, $styles, $data);
+        array_map(function ($argumentList, $markTag) use ($node, $element, $styles, $data, &$nodes) {
+            $nodes[$markTag] = array(
+                0 => $argumentList['method'],
+                1 => $argumentList['withNode'] ? $node : null,
+                2 => $argumentList['withElement'] ? $element : null,
+                3 => $argumentList['withStyles'] ? $styles : null,
+                4 => $argumentList['withData'] ? $data : null,
+                5 => $argumentList['argument1'],
+                6 => $argumentList['argument2'],
+            );
+        },
+            self::$userDefinedNodeMappings, array_keys(self::$userDefinedNodeMappings)
         );
 
         $newElement = null;
@@ -177,8 +161,8 @@ class Html
                     $arguments[$keys[$i]] = &$args[$i];
                 }
             }
-            $method = "parse{$method}";
-            $newElement = call_user_func_array(array('PhpOffice\PhpWord\Shared\Html', $method), $arguments);
+            $method = is_string($method) ? array('PhpOffice\PhpWord\Shared\Html', "parse{$method}") : $method;
+            $newElement = call_user_func_array($method, $arguments);
 
             // Retrieve back variables from arguments
             foreach ($keys as $key) {
@@ -807,5 +791,59 @@ class Html
         }
 
         return $element->addLink($target, $node->textContent, $styles['font'], $styles['paragraph']);
+    }
+
+    /**
+     * Add a custom mapping for HTML tag.
+     *
+     * @param string $htmlTag
+     * @param bool $withNode
+     * @param bool $withElement
+     * @param bool $withStyles
+     * @param bool $withData
+     * @param string $argument1
+     * @param string $argument2
+     * @param callable|string $method
+     */
+    public static function addUserDefinedNodeMapping($htmlTag, $withNode, $withElement, $withStyles, $withData, $argument1, $argument2, $method)
+    {
+        $args = compact(
+            'withNode', 'withElement','withStyles', 'withData', 'argument1', 'argument2', 'method'
+        );
+        self::$userDefinedNodeMappings[$htmlTag] = $args;
+    }
+
+    protected static function getNodeMappingTable($node, $element, $styles, $data)
+    {
+        return array(
+            // $method        $node   $element    $styles     $data   $argument1      $argument2
+            'p'         => array('Paragraph',   $node,  $element,   $styles,    null,   null,           null),
+            'h1'        => array('Heading',     null,   $element,   $styles,    null,   'Heading1',     null),
+            'h2'        => array('Heading',     null,   $element,   $styles,    null,   'Heading2',     null),
+            'h3'        => array('Heading',     null,   $element,   $styles,    null,   'Heading3',     null),
+            'h4'        => array('Heading',     null,   $element,   $styles,    null,   'Heading4',     null),
+            'h5'        => array('Heading',     null,   $element,   $styles,    null,   'Heading5',     null),
+            'h6'        => array('Heading',     null,   $element,   $styles,    null,   'Heading6',     null),
+            '#text'     => array('Text',        $node,  $element,   $styles,    null,   null,           null),
+            'strong'    => array('Property',    null,   null,       $styles,    null,   'bold',         true),
+            'b'         => array('Property',    null,   null,       $styles,    null,   'bold',         true),
+            'em'        => array('Property',    null,   null,       $styles,    null,   'italic',       true),
+            'i'         => array('Property',    null,   null,       $styles,    null,   'italic',       true),
+            'u'         => array('Property',    null,   null,       $styles,    null,   'underline',    'single'),
+            'sup'       => array('Property',    null,   null,       $styles,    null,   'superScript',  true),
+            'sub'       => array('Property',    null,   null,       $styles,    null,   'subScript',    true),
+            'span'      => array('Span',        $node,  null,       $styles,    null,   null,           null),
+            'font'      => array('Span',        $node,  null,       $styles,    null,   null,           null),
+            'table'     => array('Table',       $node,  $element,   $styles,    null,   null,           null),
+            'tr'        => array('Row',         $node,  $element,   $styles,    null,   null,           null),
+            'td'        => array('Cell',        $node,  $element,   $styles,    null,   null,           null),
+            'th'        => array('Cell',        $node,  $element,   $styles,    null,   null,           null),
+            'ul'        => array('List',        $node,  $element,   $styles,    $data,  null,           null),
+            'ol'        => array('List',        $node,  $element,   $styles,    $data,  null,           null),
+            'li'        => array('ListItem',    $node,  $element,   $styles,    $data,  null,           null),
+            'img'       => array('Image',       $node,  $element,   $styles,    null,   null,           null),
+            'br'        => array('LineBreak',   null,   $element,   $styles,    null,   null,           null),
+            'a'         => array('Link',        $node,  $element,   $styles,    null,   null,           null),
+        );
     }
 }

--- a/tests/PhpWord/Shared/HtmlTest.php
+++ b/tests/PhpWord/Shared/HtmlTest.php
@@ -632,4 +632,44 @@ class HtmlTest extends AbstractWebServerEmbeddedTest
         $this->assertTrue($doc->elementExists('/w:document/w:body/w:p/w:r/w:rPr/w:spacing'));
         $this->assertEquals(150 * 15, $doc->getElement('/w:document/w:body/w:p/w:r/w:rPr/w:spacing')->getAttribute('w:val'));
     }
+
+    public function testAddUserDefinedFunction()
+    {
+        $phpWord = new \PhpOffice\PhpWord\PhpWord();
+        $section = $phpWord->addSection();
+        $callable = $this->createPartialMock('stdClass', array('__invoke'));
+        $callable->expects(self::once())
+            ->method('__invoke')
+            ->with(
+                $this->callback(function ($node) {
+                    return $node->tagName === 'testTag' && $node->nodeValue === 'This is a custom test tag.';
+                }),
+                $this->identicalTo($section),
+                $this->equalTo(array(
+                    'font' => array(),
+                    'paragraph' => array(),
+                    'list' => array(),
+                    'table' => array(),
+                    'row' => array(),
+                    'cell' => array(),
+                )),
+                $this->equalTo(array()),
+                $this->equalTo('argument1'),
+                $this->equalTo('argument2')
+            )
+            ->willReturn(3);
+
+        Html::addUserDefinedNodeMapping(
+            'testTag',
+            true,
+            true,
+            true,
+            true,
+            'argument1',
+            'argument2',
+            $callable
+        );
+        $html = '<testTag>This is a custom test tag.</testTag>';
+        Html::addHtml($section, $html);
+    }
 }


### PR DESCRIPTION
Allows a custom mapping be defined for any HTML node. This will allow users of the library to implement their own custom mappings.

### Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

Fixes # (issue)

### Checklist:

- [ ] I have run `composer run-script check --timeout=0` and no errors were reported
- [ ] The new code is covered by unit tests (check build/coverage for coverage report)
- [ ] I have updated the documentation to describe the changes
