### PR TITLE
Headers can be added to table cell markup, but cannot be added to text runs.

### DIFF
--- a/src/PhpWord/Shared/Html.php
+++ b/src/PhpWord/Shared/Html.php
@@ -362,7 +362,7 @@ class Html
      */
     protected static function shouldAddTextRun(\DOMNode $node)
     {
-        $containsBlockElement = self::$xpath->query('.//table|./p|./ul|./ol', $node)->length > 0;
+        $containsBlockElement = self::$xpath->query('.//table|./p|./ul|./ol|./h1|./h2|./h3|./h4|./h5|./h6', $node)->length > 0;
         if ($containsBlockElement) {
             return false;
         }


### PR DESCRIPTION
### Description

If the cell contains any `<h1>` -> `<h6>` tag, avoid adding a text run here.

Attempting to export HTML with:

`<table><tr><td><h5>Heading 5</h5></td></tr></table>`

currently fails, as `<h5>` is not recognised as a tag that cannot have a text run added to it. 

It then later fails, when a text run is added. 
