### PR TITLE
Bug/parse image without extension in src

### DIFF
--- a/src/PhpWord/Shared/Html.php
+++ b/src/PhpWord/Shared/Html.php
@@ -36,13 +36,12 @@ class Html
     protected static $xpath;
     protected static $options;
     protected static $userDefinedNodeMappings = array();
-    protected static $contentTypeFileExtensionMap = [
+    protected static $contentTypeFileExtensionMap = array(
         'image/svg+xml' => 'svg',
-        'image/jpeg' => 'jpg',
-        'image/png' => 'png',
-        'image/gif' => 'gif'
-    ];
-
+        'image/jpeg'    => 'jpg',
+        'image/png'     => 'png',
+        'image/gif'     => 'gif',
+    );
 
     /**
      * Add HTML parts.
@@ -695,7 +694,7 @@ class Html
                 if (empty($match) || !isset($match[1])) {
                     $contentType = get_headers($src, 1)['Content-Type'];
 
-                    if(!array_key_exists($contentType, self::$contentTypeFileExtensionMap)){
+                    if (!array_key_exists($contentType, self::$contentTypeFileExtensionMap)) {
                         throw new \Exception("Could not load image $src");
                     }
 
@@ -826,7 +825,7 @@ class Html
     public static function addUserDefinedNodeMapping($htmlTag, $withNode, $withElement, $withStyles, $withData, $argument1, $argument2, $method)
     {
         $args = compact(
-            'withNode', 'withElement','withStyles', 'withData', 'argument1', 'argument2', 'method'
+            'withNode', 'withElement', 'withStyles', 'withData', 'argument1', 'argument2', 'method'
         );
         self::$userDefinedNodeMappings[$htmlTag] = $args;
     }

--- a/src/PhpWord/Shared/Html.php
+++ b/src/PhpWord/Shared/Html.php
@@ -36,6 +36,13 @@ class Html
     protected static $xpath;
     protected static $options;
     protected static $userDefinedNodeMappings = array();
+    protected static $contentTypeFileExtensionMap = [
+        'image/svg+xml' => 'svg',
+        'image/jpeg' => 'jpg',
+        'image/png' => 'png',
+        'image/gif' => 'gif'
+    ];
+
 
     /**
      * Add HTML parts.
@@ -684,6 +691,17 @@ class Html
                 $tmpDir = Settings::getTempDir() . '/';
                 $match = array();
                 preg_match('/.+\.(\w+)$/', $src, $match);
+
+                if (empty($match) || !isset($match[1])) {
+                    $contentType = get_headers($src, 1)['Content-Type'];
+
+                    if(!array_key_exists($contentType, self::$contentTypeFileExtensionMap)){
+                        throw new \Exception("Could not load image $src");
+                    }
+
+                    $match[1] = self::$contentTypeFileExtensionMap[$contentType];
+                }
+
                 $src = $tmpDir . uniqid() . '.' . $match[1];
 
                 $ifp = fopen($src, 'wb');

--- a/tests/PhpWord/Shared/HtmlTest.php
+++ b/tests/PhpWord/Shared/HtmlTest.php
@@ -50,7 +50,7 @@ class HtmlTest extends AbstractWebServerEmbeddedTest
 
         // Styles
         $content .= '<p style="text-decoration: underline; text-decoration: line-through; '
-                  . 'text-align: center; color: #999; background-color: #000; font-weight: bold; font-style: italic;">';
+            . 'text-align: center; color: #999; background-color: #000; font-weight: bold; font-style: italic;">';
         foreach ($styles as $style) {
             $content .= "<{$style}>{$style}</{$style}>";
         }
@@ -494,6 +494,21 @@ class HtmlTest extends AbstractWebServerEmbeddedTest
         $this->assertStringMatchesFormat('%Smso-position-horizontal:left%S', $doc->getElementAttribute($baseXpath . '[2]/w:pict/v:shape', 'style'));
     }
 
+    public function testParseRemoteImageWithoutExtension()
+    {
+        // annoyingly I have to use a valid URL to get to the code I need to test, otherwise file_get_contents fails.
+        $src = "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTABbXr4i-QODqhy7tofHYmTYh05rYPktzacw&amp;usqp=CAU";
+        $phpWord = new \PhpOffice\PhpWord\PhpWord();
+        $section = $phpWord->addSection();
+        $html = '<p><img src="https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTABbXr4i-QODqhy7tofHYmTYh05rYPktzacw&amp;usqp=CAU" data-id="null" alt="How a Random Image can help you to generate creative ideas" title=""/></p>';
+        Html::addHtml($section, $html);
+
+        $doc = TestHelperDOCX::getDocument($phpWord, 'Word2007');
+
+        $baseXpath = '/w:document/w:body/w:p/w:r';
+        $this->assertTrue($doc->elementExists($baseXpath . '/w:pict/v:shape'));
+    }
+
     /**
      * Test parsing of remote img
      */
@@ -536,8 +551,8 @@ class HtmlTest extends AbstractWebServerEmbeddedTest
         $src = 'https://fakedomain.io/images/firefox.png';
         $localPath = __DIR__ . '/../_files/images/';
         $options = array(
-          'IMG_SRC_SEARCH'  => 'https://fakedomain.io/images/',
-          'IMG_SRC_REPLACE' => $localPath,
+            'IMG_SRC_SEARCH' => 'https://fakedomain.io/images/',
+            'IMG_SRC_REPLACE' => $localPath,
         );
 
         $phpWord = new \PhpOffice\PhpWord\PhpWord();

--- a/tests/PhpWord/Shared/HtmlTest.php
+++ b/tests/PhpWord/Shared/HtmlTest.php
@@ -497,7 +497,7 @@ class HtmlTest extends AbstractWebServerEmbeddedTest
     public function testParseRemoteImageWithoutExtension()
     {
         // annoyingly I have to use a valid URL to get to the code I need to test, otherwise file_get_contents fails.
-        $src = "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTABbXr4i-QODqhy7tofHYmTYh05rYPktzacw&amp;usqp=CAU";
+        $src = 'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTABbXr4i-QODqhy7tofHYmTYh05rYPktzacw&amp;usqp=CAU';
         $phpWord = new \PhpOffice\PhpWord\PhpWord();
         $section = $phpWord->addSection();
         $html = '<p><img src="https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTABbXr4i-QODqhy7tofHYmTYh05rYPktzacw&amp;usqp=CAU" data-id="null" alt="How a Random Image can help you to generate creative ideas" title=""/></p>';
@@ -551,7 +551,7 @@ class HtmlTest extends AbstractWebServerEmbeddedTest
         $src = 'https://fakedomain.io/images/firefox.png';
         $localPath = __DIR__ . '/../_files/images/';
         $options = array(
-            'IMG_SRC_SEARCH' => 'https://fakedomain.io/images/',
+            'IMG_SRC_SEARCH'  => 'https://fakedomain.io/images/',
             'IMG_SRC_REPLACE' => $localPath,
         );
 
@@ -661,12 +661,12 @@ class HtmlTest extends AbstractWebServerEmbeddedTest
                 }),
                 $this->identicalTo($section),
                 $this->equalTo(array(
-                    'font' => array(),
+                    'font'      => array(),
                     'paragraph' => array(),
-                    'list' => array(),
-                    'table' => array(),
-                    'row' => array(),
-                    'cell' => array(),
+                    'list'      => array(),
+                    'table'     => array(),
+                    'row'       => array(),
+                    'cell'      => array(),
                 )),
                 $this->equalTo(array()),
                 $this->equalTo('argument1'),


### PR DESCRIPTION
### Description
Handling on image urls that do not contain a file extension. we instead look up the mime type and derive a supported image extension from that

Fixes # (issue)

### Checklist:

- [x] I have run `composer run-script check --timeout=0` and no errors were reported
- [x] The new code is covered by unit tests (check build/coverage for coverage report)
- [ ] I have updated the documentation to describe the changes
