### PR TITLE
Don't urldecode image src attributes, this causes issues with signed urls

### DIFF
--- a/src/PhpWord/Shared/Html.php
+++ b/src/PhpWord/Shared/Html.php
@@ -817,7 +817,7 @@ class Html
                     break;
             }
         }
-        $originSrc = $src;
+
         if (strpos($src, 'data:image') !== false) {
             $tmpDir = Settings::getTempDir() . '/';
 
@@ -833,7 +833,6 @@ class Html
                 fclose($ifp);
             }
         }
-        $src = urldecode($src);
 
         if (!is_file($src)
             && !is_null(self::$options)
@@ -872,7 +871,7 @@ class Html
         if (is_file($src)) {
             $newElement = $element->addImage($src, $style);
         } else {
-            throw new \Exception("Could not load image $originSrc");
+            throw new \Exception("Could not load image $src");
         }
 
         return $newElement;

--- a/tests/PhpWord/Shared/HtmlTest.php
+++ b/tests/PhpWord/Shared/HtmlTest.php
@@ -534,6 +534,24 @@ class HtmlTest extends AbstractWebServerEmbeddedTest
     }
 
     /**
+     * Test parsing of remote img with signed url
+     */
+    public function testParseRemoteSignedImage()
+    {
+        $src = 'https://gathertest.imgix.net/Nw/vmfKMPzVP6uolWQG?ar=1%3A1&auto=format%2Ccompress&fit=crop&max-height=800&q=75&s=694c91d545685c82215985a09bda7d05';
+
+        $phpWord = new \PhpOffice\PhpWord\PhpWord();
+        $section = $phpWord->addSection();
+        $html = '<p><img src="' . $src . '"/></p>';
+        Html::addHtml($section, $html);
+
+        $doc = TestHelperDOCX::getDocument($phpWord, 'Word2007');
+
+        $baseXpath = '/w:document/w:body/w:p/w:r';
+        $this->assertTrue($doc->elementExists($baseXpath . '/w:pict/v:shape'));
+    }
+
+    /**
      * Test parsing embedded image
      */
     public function testParseEmbeddedImage()


### PR DESCRIPTION
### Description

Fixes [this issue](https://github.com/PHPOffice/PHPWord/issues/2141)

### Checklist:

- [x] I have run `composer run-script check --timeout=0` and no errors were reported
- [x] The new code is covered by unit tests (check build/coverage for coverage report)
- [ ] I have updated the documentation to describe the changes
