### PR TITLE
Supress libpng warning about too many profiles

### DIFF
--- a/src/PhpWord/Writer/AbstractWriter.php
+++ b/src/PhpWord/Writer/AbstractWriter.php
@@ -351,7 +351,7 @@ abstract class AbstractWriter implements WriterInterface
 
             // Retrive GD image content or get local media
             if (isset($element['isMemImage']) && $element['isMemImage']) {
-                $image = call_user_func($element['createFunction'], $element['source']);
+                $image = @call_user_func($element['createFunction'], $element['source']);
                 if ($element['imageType'] === 'image/png') {
                     // PNG images need to preserve alpha channel information
                     imagesavealpha($image, true);


### PR DESCRIPTION
### Description

We have issues when trying to add a Bynder PNG to export in Word 2007 format. This is due to libpng giving a warning about `too many profiles`  that for some reason we can figure out is causing the save to crash rather than report the warning.

Suppressing the warning still allows the png to be saved to the doc

